### PR TITLE
turn on annotation mode, add readme for Google Script App

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,10 @@ Register the code with Cloud Functions the following command. You need to create
 - Annotation mode usage: to use pdf2audiobook for generating annotation data, set `ANNOTATION_MODE = True` and re-register the code with Cloud Funtions, so the tool will generate CSV files for annotation instead of mp3 files.
 
 - Annotation tool: use /apps-script code for running the annotation tool with Google Apps Script
+1. Install Node.JS (version higher than 10.0.0) [Tutorial here](https://hackernoon.com/how-to-install-node-js-on-ubuntu-16-04-18-04-using-nvm-node-version-manager-668a7166b854 "hackernoon's Homepage") 
+2. Install Google clasp (`sudo npm install @google/clasp -g`)
+3. Go to script.google.com, specifically [https://script.google.com/home/usersettings],
+4. Enable Google App Scripts API (`gcloud services enable cloudapis.googleapis.com`)
+5. Run `clasp login`, `clasp push` in the /apps-script directory
+
 

--- a/deploy_all.sh
+++ b/deploy_all.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+gcloud services enable cloudfunctions.googleapis.com
+gcloud services enable vision.googleapis.com          
+gcloud services enable cloudapis.googleapis.com     
+gcloud services enable automl.googleapis.com 

--- a/functions/app/main.py
+++ b/functions/app/main.py
@@ -37,7 +37,7 @@ from google.cloud import automl_v1beta1 as automl
 from google.protobuf import json_format
 
 # generate PNGs for each page and labeled CSV for annotation
-ANNOTATION_MODE = False
+ANNOTATION_MODE = True
 
 # AutoML Tables configs
 compute_region = "us-central1"


### PR DESCRIPTION
1. turn on annotation mode
2. update readme  for a Google Script App tutorial
3. add a deploy_all.sh script that enables all the apis and deploys the script 